### PR TITLE
Template not found issue

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -7,6 +7,7 @@ from flask import Flask, render_template
 import importlib
 import sys
 import os
+from pathlib import Path
 from dotenv import load_dotenv
 
 # טעינת משתני סביבה מקובץ .env (אם קיים)
@@ -18,7 +19,12 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from config import Config
 
 
-app = Flask(__name__)
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATES_DIR = PROJECT_ROOT / "templates"
+
+# Flask defaults to searching for templates relative to this module/package.
+# In this repo templates live at "<project_root>/templates", so we set it explicitly.
+app = Flask(__name__, template_folder=str(TEMPLATES_DIR))
 app.config.from_object(Config)
 
 


### PR DESCRIPTION
Explicitly set Flask's template folder to resolve `TemplateNotFound` errors for `index.html`.

The Flask app was instantiated within the `engine` package, causing it to default to searching for templates in `engine/templates/`. This change directs Flask to the correct top-level `templates/` directory.

---
<a href="https://cursor.com/background-agent?bcId=bc-552a1bbe-ac36-4a10-84be-486c61b0fdb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-552a1bbe-ac36-4a10-84be-486c61b0fdb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

