### PR TITLE
Favicon request handling

### DIFF
--- a/engine/app.py
+++ b/engine/app.py
@@ -3,7 +3,7 @@ Engine - ליבת המערכת
 מנוע Flask עם טעינה דינמית של פלאגינים
 """
 
-from flask import Flask, render_template
+from flask import Flask, render_template, redirect, url_for
 import importlib
 import sys
 import os
@@ -21,10 +21,19 @@ from config import Config
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 TEMPLATES_DIR = PROJECT_ROOT / "templates"
+STATIC_DIR = PROJECT_ROOT / "static"
 
 # Flask defaults to searching for templates relative to this module/package.
 # In this repo templates live at "<project_root>/templates", so we set it explicitly.
-app = Flask(__name__, template_folder=str(TEMPLATES_DIR))
+#
+# We also explicitly set a project-level static directory so Render/Flask can serve assets
+# like favicon files from "<project_root>/static".
+app = Flask(
+    __name__,
+    template_folder=str(TEMPLATES_DIR),
+    static_folder=str(STATIC_DIR),
+    static_url_path="/static",
+)
 app.config.from_object(Config)
 
 
@@ -75,6 +84,17 @@ def dashboard():
     return render_template('index.html', 
                           widgets=widgets, 
                           bot_name=Config.BOT_NAME)
+
+
+@app.get("/favicon.ico")
+def favicon():
+    """
+    Handle default browser favicon requests.
+
+    Many browsers request "/favicon.ico" even when the HTML declares a different icon.
+    We redirect to our SVG favicon to avoid 404 noise in logs.
+    """
+    return redirect(url_for("static", filename="favicon.svg"))
 
 
 @app.route('/health')

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="Modular Bot">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#00a3ff"/>
+      <stop offset="1" stop-color="#2ecc71"/>
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#0f0f23"/>
+  <rect x="8" y="8" width="48" height="48" rx="12" fill="url(#g)" opacity="0.22"/>
+  <g fill="none" stroke="url(#g)" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M22 26c0-4 3-7 7-7h6c4 0 7 3 7 7v12c0 4-3 7-7 7h-6c-4 0-7-3-7-7V26z"/>
+    <path d="M26 26h12"/>
+    <path d="M26 38h12"/>
+  </g>
+  <g fill="#0f0f23">
+    <circle cx="26" cy="32" r="2.6"/>
+    <circle cx="38" cy="32" r="2.6"/>
+  </g>
+</svg>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ bot_name }}</title>
+
+    <!-- Favicon -->
+    <link rel="icon" href="{{ url_for('static', filename='favicon.svg') }}" type="image/svg+xml">
+    <link rel="alternate icon" href="{{ url_for('static', filename='favicon.svg') }}">
     
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">


### PR DESCRIPTION
Add favicon support to prevent 404 errors for `/favicon.ico` and display a proper application icon.

Many browsers automatically request `/favicon.ico`, leading to noisy 404 errors in logs when not explicitly handled. This PR configures Flask to serve static assets and redirects `/favicon.ico` requests to the new SVG favicon.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad624d00-ff10-411d-a6fe-6454a64385e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ad624d00-ff10-411d-a6fe-6454a64385e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

