### PR TITLE
הוספת מערכת התראות לאדמין על שגיאות API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,15 @@ DEBUG=False
 # Telegram
 # TELEGRAM_TOKEN=your-telegram-token
 
+# Admin Notifications - Chat ID לקבלת התראות על שגיאות
+# כדי לקבל את ה-Chat ID שלך, שלח הודעה ל-@userinfobot
+# ADMIN_CHAT_ID=123456789
+
 # GitHub (used by Architect plugin)
 # GITHUB_TOKEN=ghp_yourtoken
 # GITHUB_USER=your-username-or-org
 # GITHUB_REPO=your-repo-name
 # GITHUB_BRANCH=main
+
+# Anthropic Claude API (used by Architect plugin)
+# ANTHROPIC_API_KEY=sk-ant-...

--- a/config.py
+++ b/config.py
@@ -23,6 +23,9 @@ GITHUB_BRANCH = os.environ.get("GITHUB_BRANCH")
 # Anthropic (for Architect plugin)
 ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
 
+# Admin notifications
+ADMIN_CHAT_ID = os.environ.get("ADMIN_CHAT_ID")  # Telegram chat ID for alerts
+
 
 class Config:
     """הגדרות כלליות לדשבורד הבוט"""
@@ -57,6 +60,9 @@ class Config:
 
     # Anthropic (for Architect plugin)
     ANTHROPIC_API_KEY = ANTHROPIC_API_KEY
+
+    # Admin notifications
+    ADMIN_CHAT_ID = ADMIN_CHAT_ID
 
 
 # Convenience module-level aliases (for engine/app.py usage)


### PR DESCRIPTION
- פונקציית _notify_admin שולחת התראות לטלגרם
- זיהוי שגיאות ספציפיות מ-Claude API: • 429 - נגמרה מכסת הטוקנים (quota) • 401 - מפתח API לא תקין • 400 - בעיית חיוב/billing • 500+ - שגיאת שרת
- ADMIN_CHAT_ID בקונפיגורציה לקבלת התראות
- עדכון .env.example עם ההגדרות החדשות