### PR TITLE
Bot id key error

### DIFF
--- a/plugins/architect.py
+++ b/plugins/architect.py
@@ -134,6 +134,7 @@ INVALID_TOKEN_MESSAGE = """⚠️ הטוקן לא נראה תקין.
 נסה שוב או שלח /cancel לביטול."""
 
 # קוד עזר לשמירת מצב - יתווסף אוטומטית לכל בוט שנוצר
+# Note: Double curly braces {{ }} are escaped for .format() - they become single { } in output
 STATE_HELPER_CODE = '''# === MongoDB State Helpers (auto-generated) ===
 import os
 from pymongo import MongoClient
@@ -172,8 +173,8 @@ def save_state(user_id, key, value):
         return False
     try:
         db.bot_states.update_one(
-            {"bot_id": BOT_ID, "user_id": str(user_id), "key": key},
-            {"$set": {"value": value}},
+            {{"bot_id": BOT_ID, "user_id": str(user_id), "key": key}},
+            {{"$set": {{"value": value}}}},
             upsert=True
         )
         return True
@@ -196,7 +197,7 @@ def load_state(user_id, key, default=None):
     if db is None:
         return default
     try:
-        doc = db.bot_states.find_one({"bot_id": BOT_ID, "user_id": str(user_id), "key": key})
+        doc = db.bot_states.find_one({{"bot_id": BOT_ID, "user_id": str(user_id), "key": key}})
         return doc.get("value", default) if doc else default
     except Exception:
         return default


### PR DESCRIPTION
Escape literal curly braces in `STATE_HELPER_CODE` to fix `KeyError` during string formatting.

The `STATE_HELPER_CODE` string contained Python dictionary literals like `{"bot_id": BOT_ID, ...}`. When `.format()` was called on this string, Python interpreted all curly braces as format placeholders, leading to `KeyError: '"bot_id"'` because `"bot_id"` was not a valid format key. Doubling the literal curly braces `{{` and `}}` prevents this misinterpretation, allowing only `{bot_id}` to be treated as a format placeholder.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e6c3838-88f0-44d0-a2a4-d50d93ec5196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e6c3838-88f0-44d0-a2a4-d50d93ec5196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

